### PR TITLE
[Docker] BE Docker 배포파일 작성 (현재 개발된 서비스까지)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ out/
 ### VS Code ###
 .vscode/
 bin/
+
+docker/mariadb/mariadb.env
+docker/rabbitmq/rabbitmq.conf

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,36 @@
+# Docker compose로 애플리케이션 실행하기 (개발환경에서 사용)
+
+## 실행방법
+
+1. 각 서비스에서 네이티브 빌드팩으로 도커 이미지 생성하기
+```
+./gradlew bootBuildImage
+```
+
+2. docker compose 파일이 존재하는 디렉토리로 이동
+```
+cd ./docker
+```
+
+3. docker compose 실행하기
+- 단일 서비스 실행하기 (config-service만 실행하고 싶을때)
+```
+docker compose up -d config-service
+```
+- 모든 서비스 한 번에 실행하기
+```
+docker compose up -d
+```
+
+4. docker compose 종료하기
+- 단일 서비스 종료하기 (config-service만 실행하고 싶을때)
+```
+docker compose down config-service
+```
+- 모든 서비스 한 번에 실행하기
+```
+docker compose down
+```
+
+## 주의 사항
+- `/mariadb/mariadb.env`와 `/rabbitmq/rabbitmq.conf` 파일에는 사용자와 비밀번호 정보가 들어 있으므로 따로 commit하지 않았습니다.

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,3 +34,20 @@ docker compose down
 
 ## 주의 사항
 - `/mariadb/mariadb.env`와 `/rabbitmq/rabbitmq.conf` 파일에는 사용자와 비밀번호 정보가 들어 있으므로 따로 commit하지 않았습니다.
+- 각 서비스 별로 deploy 브랜치에 있는 수정 사항을 반영해야 실행 가능합니다. 
+    - build.gradle에 다음과 같은 코드가 존재해야함
+        ```
+        bootBuildImage{
+            builder = "docker.io/paketobuildpacks/builder-jammy-base"
+            imageName = "zipbob-${project.name}"
+            environment = ["BP_JVM_VERSION" : "17.*"]
+
+            docker {
+                publishRegistry {
+                    url = project.findProperty("registryUrl")
+                    username = project.findProperty("registryUsername")
+                    password = project.findProperty("registryToken")
+                }
+            }
+        }
+        ```

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,117 @@
+services:
+
+  # Applications
+  
+  zipbob-config-service:
+    platform: linux/amd64
+    image: "zipbob-config-service"
+    container_name: "zipbob-config-service"
+    ports:
+      - 8888:8888
+      - 9888:9888
+    healthcheck:
+      test: [ "CMD", "/workspace/health-check" ]
+      interval: 3s
+      retries: 10
+      timeout: 5s
+      start_period: 10s
+    environment:
+      - SPRING_PROFILES_ACTIVE=native
+      - BPL_JVM_THREAD_COUNT=50
+      - BPL_DEBUG_ENABLED=true
+      - BPL_DEBUG_PORT=9888
+      - NATIVE_LOCATION=/config
+      - THC_PORT=8888
+      - THC_PATH=/actuator/health
+    volumes:
+      - ../../native-config-repo:/config
+
+  zipbob-edge-service:
+    platform: linux/amd64
+    depends_on:
+      zipbob-config-service:
+        condition: service_healthy
+      zipbob-mariadb:
+        condition: service_started
+      zipbob-redis:
+        condition: service_started
+    image: "zipbob-edge-service"
+    container_name: "zipbob-edge-service"
+    ports:
+      - 9000:9000
+      - 8000:8000
+    environment:
+      - BPL_DEBUG_ENABLED=true
+      - BPL_DEBUG_PORT=8000
+      - SPRING_DATASOURCE_URL=jdbc:mariadb://zipbob-mariadb:3306/members
+      - SPRING_DATA_REDIS_HOST=zipbob-redis
+      - SPRING_CLOUD_CONFIG_URI=http://zipbob-config-service:8888
+      - INGREDIENTS_MANAGE_SERVICE_URI=http://ingredients-manage-service:9001
+      - SPRING_CLOUD_CONFIG_FAIL_FAST=true
+
+  ingredients-manage-service:
+    platform: linux/amd64
+    depends_on:
+      zipbob-config-service:
+        condition: service_healthy
+      zipbob-mariadb:
+        condition: service_started
+      zipbob-rabbitmq:
+        condition: service_started
+    image: "ingredients-manage-service"
+    container_name: "ingredients-manage-service"
+    ports:
+      - 9001:9001
+      - 8001:8001
+    environment:
+      - BPL_JVM_THREAD_COUNT=50
+      - BPL_DEBUG_ENABLED=true
+      - BPL_DEBUG_PORT=8001
+      - SPRING_CLOUD_CONFIG_URI=http://zipbob-config-service:8888
+      - SPRING_DATASOURCE_URL=jdbc:mariadb://zipbob-mariadb:3306/members
+      - SPRING_RABBITMQ_HOST=zipbob-rabbitmq
+      - SPRING_CLOUD_CONFIG_FAIL_FAST=true
+
+  recipe-review-service:
+    platform: linux/amd64
+    depends_on:
+      zipbob-config-service:
+        condition: service_healthy
+    image: "recipe-review-service"
+    container_name: "recipe-review-service"
+    ports:
+      - 9002:9002
+      - 8002:8002
+    environment:
+      - BPL_JVM_THREAD_COUNT=50
+      - BPL_DEBUG_ENABLED=true
+      - BPL_DEBUG_PORT=8001
+      - SPRING_CLOUD_CONFIG_URI=http://zipbob-config-service:8888
+      - SPRING_CLOUD_CONFIG_FAIL_FAST=true
+
+  # Backing Services
+
+  zipbob-mariadb:
+    image: "mariadb:latest"
+    container_name: "zipbob-mariadb"
+    ports:
+      - 3306:3306
+    env_file:
+      - ./mariadb/mariadb.env
+    volumes:
+      - ./mariadb/init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  zipbob-redis:
+    image: "redis:latest"
+    container_name: "zipbob-redis"
+    ports:
+      - 6379:6379
+
+  zipbob-rabbitmq:
+    image: rabbitmq:latest
+    container_name: zipbob-rabbitmq
+    ports:
+      - 5672:5672
+      - 15672:15672
+    volumes:
+      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf

--- a/docker/mariadb/init.sql
+++ b/docker/mariadb/init.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE members;
+GRANT ALL PRIVILEGES ON members.* TO 'zipbob'@'%';
+FLUSH PRIVILEGES;


### PR DESCRIPTION
## 🌲 작업한 브랜치
- feature/docker

## 📚 작업한 내용
- Docker Compose를 활용하여 개발 환경에서 `docker compose up -d` 명령어를 실행하면 RabbitMQ, MariaDB, Redis를 포함한 모든 서비스가 한 번에 실행되도록 하였습니다.
- 서비스 간 의존성을 관리하기 위해, Config Service가 완전히 작동하는 것을 확인한 후에만 연관된 서비스들이 실행되도록 Health Check를 구성하였습니다.
- 로컬환경에서 실행할 수 있도록 README.md 파일을 작성하였습니다.

## ❗이슈 사항
- 보안상 실행에 필요한 mariadb.env와 rabbitmq.conf는 올리지 않았습니다.
- 모든 서비스의 deploy 브랜치에 있는 build.gradle의 수정사항을 반영해야 정상적인 도커 이미지를 만들고 빌드할 수 있습니다.
- 클라우드 네이티브 빌드팩을 이용하여 도커 이미지를 만드는 과정 중 `curl` 명령어가 컨테이너 내부에 깔리지 않는 현상을 겪었습니다.
  - paketo-buildpacks/health-checker 를 이용하여 해결하였습니다.

## ⭐ 연관된 이슈
Close #1 

## 🤔 궁금한 점